### PR TITLE
Add functionality to add maximum volunteers to event

### DIFF
--- a/src/main/java/seedu/address/logic/commands/eventcommands/EventAddMaterialCommand.java
+++ b/src/main/java/seedu/address/logic/commands/eventcommands/EventAddMaterialCommand.java
@@ -108,7 +108,8 @@ public class EventAddMaterialCommand extends Command {
                 eventToEdit.getDescription(),
                 updatedMaterials,
                 eventToEdit.getBudget(),
-                eventToEdit.getAssignedVolunteers());
+                eventToEdit.getAssignedVolunteers(),
+                eventToEdit.getMaxVolunteerSize());
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/eventvolunteercommands/EventAddVolunteerCommand.java
+++ b/src/main/java/seedu/address/logic/commands/eventvolunteercommands/EventAddVolunteerCommand.java
@@ -32,6 +32,8 @@ public class EventAddVolunteerCommand extends Command {
             + PREFIX_VOLUNTEER_ID + "2 ";
     public static final String MESSAGE_SUCCESS = "New volunteer added to event.\nUpdated Event: %1$s\n"
             + "Event currently has %2$d volunteers";
+    public static final String MESSAGE_EVENT_FULL = "This event has already reached a maximum of %1$d volunteer(s), "
+            + "and is unable to accept any more volunteers";
     public static final String MESSAGE_DUPLICATE_VOLUNTEER = "This volunteer is already assigned to this event";
     private final Index assignedEventIndex;
 
@@ -62,6 +64,10 @@ public class EventAddVolunteerCommand extends Command {
         Volunteer volunteerToAssign = lastShownVolunteerList.get(assignedVolunteerIndex.getZeroBased());
         if (eventToAssign.hasVolunteer(volunteerToAssign)) {
             throw new CommandException(MESSAGE_DUPLICATE_VOLUNTEER);
+        }
+        if (eventToAssign.getAssignedVolunteers().size() >= eventToAssign.getMaxVolunteerSize().maxVolunteerSize) {
+            throw new CommandException(String.format(MESSAGE_EVENT_FULL,
+                    eventToAssign.getMaxVolunteerSize().maxVolunteerSize));
         }
         Volunteer updatedVolunteer = volunteerToAssign.addEvent(eventToAssign);
         Event updatedEvent = eventToAssign.addVolunteer(volunteerToAssign);

--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -18,4 +18,5 @@ public class CliSyntax {
     public static final Prefix PREFIX_SKILL = new Prefix("s/");
     public static final Prefix PREFIX_EVENT_ID = new Prefix("eid/");
     public static final Prefix PREFIX_VOLUNTEER_ID = new Prefix("vid/");
+    public static final Prefix PREFIX_MAX_VOLUNTEER_SIZE = new Prefix("vs/");
 }

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -16,6 +16,7 @@ import seedu.address.model.event.Description;
 import seedu.address.model.event.EventName;
 import seedu.address.model.event.Location;
 import seedu.address.model.event.Material;
+import seedu.address.model.event.MaxVolunteerSize;
 import seedu.address.model.event.Role;
 import seedu.address.model.skill.Skill;
 import seedu.address.model.volunteer.Email;
@@ -217,6 +218,21 @@ public class ParserUtil {
             throw new ParseException(Name.MESSAGE_CONSTRAINTS);
         }
         return new Name(trimmedName);
+    }
+
+    /**
+     * Parses a {@code String mvs} into a {@code MaxVolunteerSize}.
+     * Leading and trailing whitespaces will be trimmed.
+     *
+     * @throws ParseException if the given {@code mvs} is invalid.
+     */
+    public static MaxVolunteerSize parseMaxVolunteerSize(String mvs) throws ParseException {
+        requireNonNull(mvs);
+        String trimmedMvs = mvs.trim();
+        if (!MaxVolunteerSize.isValidMaxVolunteerSize(trimmedMvs)) {
+            throw new ParseException(MaxVolunteerSize.MESSAGE_CONSTRAINTS);
+        }
+        return new MaxVolunteerSize(trimmedMvs);
     }
 
     /**

--- a/src/main/java/seedu/address/logic/parser/eventcommandparsers/EventCreateCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/eventcommandparsers/EventCreateCommandParser.java
@@ -7,6 +7,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_DESCRIPTION;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_END_DATETIME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_LOCATION;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_MATERIAL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_MAX_VOLUNTEER_SIZE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ROLE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_START_DATETIME;
@@ -29,6 +30,7 @@ import seedu.address.model.event.Event;
 import seedu.address.model.event.EventName;
 import seedu.address.model.event.Location;
 import seedu.address.model.event.Material;
+import seedu.address.model.event.MaxVolunteerSize;
 import seedu.address.model.event.Role;
 import seedu.address.model.volunteer.Name;
 
@@ -46,7 +48,8 @@ public class EventCreateCommandParser implements Parser<EventCreateCommand> {
     public EventCreateCommand parse(String args) throws ParseException {
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_ROLE, PREFIX_START_DATETIME,
-                        PREFIX_END_DATETIME, PREFIX_LOCATION, PREFIX_DESCRIPTION, PREFIX_MATERIAL, PREFIX_BUDGET);
+                        PREFIX_END_DATETIME, PREFIX_LOCATION, PREFIX_DESCRIPTION, PREFIX_MATERIAL, PREFIX_BUDGET,
+                        PREFIX_MAX_VOLUNTEER_SIZE);
 
         if (!arePrefixesPresent(argMultimap, PREFIX_NAME, PREFIX_ROLE, PREFIX_START_DATETIME,
                 PREFIX_LOCATION, PREFIX_DESCRIPTION)
@@ -56,7 +59,7 @@ public class EventCreateCommandParser implements Parser<EventCreateCommand> {
         }
 
         argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NAME, PREFIX_START_DATETIME, PREFIX_END_DATETIME,
-                PREFIX_LOCATION, PREFIX_DESCRIPTION, PREFIX_BUDGET);
+                PREFIX_LOCATION, PREFIX_DESCRIPTION, PREFIX_BUDGET, PREFIX_MAX_VOLUNTEER_SIZE);
         EventName eventName = ParserUtil.parseEventName(argMultimap.getValue(PREFIX_NAME).get());
         Set<Role> roleList = ParserUtil.parseRoles(argMultimap.getAllValues(PREFIX_ROLE));
         DateTime startDate = ParserUtil.parseDateAndTime(argMultimap.getValue(PREFIX_START_DATETIME).get());
@@ -83,8 +86,15 @@ public class EventCreateCommandParser implements Parser<EventCreateCommand> {
             budget = ParserUtil.parseBudget(argMultimap.getValue(PREFIX_BUDGET).get());
         }
 
+        // Check if the command contains the optional max volunteer size field
+        MaxVolunteerSize maxVolunteerSize = new MaxVolunteerSize();
+        if (args.contains(PREFIX_MAX_VOLUNTEER_SIZE.getPrefix())) {
+            maxVolunteerSize = ParserUtil
+                    .parseMaxVolunteerSize(argMultimap.getValue(PREFIX_MAX_VOLUNTEER_SIZE).get());
+        }
+
         Event event = new Event(eventName, roleList, startDate, endDate, location, description, materialList, budget,
-                new HashSet<Name>());
+                new HashSet<Name>(), maxVolunteerSize);
 
         return new EventCreateCommand(event);
     }

--- a/src/main/java/seedu/address/logic/parser/eventcommandparsers/EventEditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/eventcommandparsers/EventEditCommandParser.java
@@ -8,6 +8,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_DESCRIPTION;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_END_DATETIME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_LOCATION;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_MATERIAL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_MAX_VOLUNTEER_SIZE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ROLE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_START_DATETIME;
@@ -43,7 +44,8 @@ public class EventEditCommandParser implements Parser<EventEditCommand> {
         requireNonNull(args);
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_ROLE, PREFIX_START_DATETIME,
-                        PREFIX_END_DATETIME, PREFIX_LOCATION, PREFIX_DESCRIPTION, PREFIX_MATERIAL, PREFIX_BUDGET);
+                        PREFIX_END_DATETIME, PREFIX_LOCATION, PREFIX_DESCRIPTION, PREFIX_MATERIAL, PREFIX_BUDGET,
+                        PREFIX_MAX_VOLUNTEER_SIZE);
 
         Index index;
         DateTime startDate;
@@ -73,6 +75,10 @@ public class EventEditCommandParser implements Parser<EventEditCommand> {
         }
         if (argMultimap.getValue(PREFIX_BUDGET).isPresent()) {
             editEventDescriptor.setBudget(ParserUtil.parseBudget(argMultimap.getValue(PREFIX_BUDGET).get()));
+        }
+        if (argMultimap.getValue(PREFIX_MAX_VOLUNTEER_SIZE).isPresent()) {
+            editEventDescriptor.setMaxVolunteerSize(
+                    ParserUtil.parseMaxVolunteerSize(argMultimap.getValue(PREFIX_MAX_VOLUNTEER_SIZE).get()));
         }
 
         if (argMultimap.getValue(PREFIX_START_DATETIME).isPresent()) {

--- a/src/main/java/seedu/address/model/event/Event.java
+++ b/src/main/java/seedu/address/model/event/Event.java
@@ -31,14 +31,16 @@ public class Event implements Comparable<Event> {
     private final Set<Material> materials;
     private final Budget budget;
     private final Set<Name> assignedVolunteers;
+    private final MaxVolunteerSize maxVolunteerSize;
 
     /**
      * Every field must be present and not null.
      */
     public Event(EventName eventName, Set<Role> roles, DateTime startDate, DateTime endDate, Location location,
-                 Description description, Set<Material> materials, Budget budget, Set<Name> assignedVolunteers) {
+                 Description description, Set<Material> materials, Budget budget, Set<Name> assignedVolunteers,
+                 MaxVolunteerSize maxVolunteerSize) {
         requireAllNonNull(eventName, roles, startDate, endDate, location, description, materials, budget,
-                assignedVolunteers);
+                assignedVolunteers, maxVolunteerSize);
         this.eventName = eventName;
         this.roles = roles;
         this.startDate = startDate;
@@ -48,6 +50,7 @@ public class Event implements Comparable<Event> {
         this.materials = materials;
         this.budget = budget;
         this.assignedVolunteers = assignedVolunteers;
+        this.maxVolunteerSize = maxVolunteerSize;
     }
 
     public EventName getEventName() {
@@ -72,6 +75,9 @@ public class Event implements Comparable<Event> {
     }
     public Description getDescription() {
         return description;
+    }
+    public MaxVolunteerSize getMaxVolunteerSize() {
+        return maxVolunteerSize;
     }
     /**
      * Returns an immutable Material set, which throws {@code UnsupportedOperationException}
@@ -132,7 +138,7 @@ public class Event implements Comparable<Event> {
         }
 
         return new Event(eventName, newRoles, startDate, endDate,
-                location, description, materials, budget, newVolunteers);
+                location, description, materials, budget, newVolunteers, maxVolunteerSize);
     }
     /**
      * Checks if a volunteer is already in {@code assignedVolunteers}.
@@ -163,7 +169,7 @@ public class Event implements Comparable<Event> {
         }
 
         return new Event(eventName, newRoles, startDate, endDate,
-                location, description, materials, budget, newVolunteers);
+                location, description, materials, budget, newVolunteers, maxVolunteerSize);
     }
     /**
      * Returns a set of volunteers from the {@code assignedVolunteers}.
@@ -232,14 +238,15 @@ public class Event implements Comparable<Event> {
                 && description.equals(otherEvent.description)
                 && materials.equals(otherEvent.materials)
                 && budget.equals(otherEvent.budget)
-                && assignedVolunteers.equals(otherEvent.assignedVolunteers);
+                && assignedVolunteers.equals(otherEvent.assignedVolunteers)
+                && maxVolunteerSize.equals(otherEvent.maxVolunteerSize);
     }
 
     @Override
     public int hashCode() {
         // use this method for custom fields hashing instead of implementing your own
         return Objects.hash(eventName, roles, startDate, endDate, location, description, materials, budget,
-                assignedVolunteers);
+                assignedVolunteers, maxVolunteerSize);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/event/MaxVolunteerSize.java
+++ b/src/main/java/seedu/address/model/event/MaxVolunteerSize.java
@@ -1,0 +1,105 @@
+package seedu.address.model.event;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.util.AppUtil.checkArgument;
+
+/**
+ * Represents a Event's maximum volunteer size in the event storage.
+ * Guarantees: immutable; is valid as declared in {@link #isValidMaxVolunteerSize(String)}
+ */
+public class MaxVolunteerSize {
+
+    public static final String MESSAGE_CONSTRAINTS =
+            "The maximum volunteer size should be a non-zero unsigned integer, or 0 for no limit.";
+
+    /*
+     * The first character of the event name must not be a whitespace,
+     * otherwise " " (a blank string) becomes a valid input.
+     * The expression allows for multiple words to be inputted.
+     */
+    public static final String VALIDATION_REGEX = "[0-9]+";
+
+    public final long maxVolunteerSize;
+
+    /**
+     * Constructs a {@code MaxVolunteerSize} with the default value of {@code Long.MAX_VALUE}.
+     */
+    public MaxVolunteerSize() {
+        maxVolunteerSize = Long.MAX_VALUE;
+    }
+
+    /**
+     * Constructs a {@code MaxVolunteerSize}.
+     *
+     * @param maxVolunteerSize A valid unsigned long integer.
+     */
+    public MaxVolunteerSize(String maxVolunteerSize) {
+        requireNonNull(maxVolunteerSize);
+        checkArgument(isValidMaxVolunteerSize(maxVolunteerSize), MESSAGE_CONSTRAINTS);
+
+        // NumberFormatException is handled in the checkArgument call above
+        long maxVolunteerSizeLong = Long.parseLong(maxVolunteerSize);
+        this.maxVolunteerSize = maxVolunteerSizeLong != 0
+                ? maxVolunteerSizeLong
+                : Long.MAX_VALUE;
+    }
+
+    /**
+     * Constructs a {@code MaxVolunteerSize} from a long integer.
+     *
+     * @param maxVolunteerSize A valid unsigned long integer.
+     */
+    public MaxVolunteerSize(long maxVolunteerSize) {
+        checkArgument(isValidMaxVolunteerSize(maxVolunteerSize), MESSAGE_CONSTRAINTS);
+        if (maxVolunteerSize == 0) {
+            this.maxVolunteerSize = Long.MAX_VALUE;
+        } else {
+            this.maxVolunteerSize = maxVolunteerSize;
+        }
+    }
+
+    /**
+     * Returns true if a given string is a valid maximum volunteer size.
+     */
+    public static boolean isValidMaxVolunteerSize(String test) {
+        try {
+            return test.matches(VALIDATION_REGEX)
+                    && isValidMaxVolunteerSize(Long.parseLong(test));
+        } catch (NumberFormatException nfe) {
+            return false;
+        }
+    }
+
+    /**
+     * Returns true if a given long integer is a valid maximum volunteer size.
+     */
+    public static boolean isValidMaxVolunteerSize(long test) {
+        return (test >= 0);
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(maxVolunteerSize);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof MaxVolunteerSize)) {
+            return false;
+        }
+
+        MaxVolunteerSize otherMaxVolunteerSize = (MaxVolunteerSize) other;
+        return maxVolunteerSize == otherMaxVolunteerSize.maxVolunteerSize;
+    }
+
+    @Override
+    public int hashCode() {
+        return Long.valueOf(maxVolunteerSize).hashCode();
+    }
+
+}

--- a/src/main/java/seedu/address/storage/event/JsonAdaptedEvent.java
+++ b/src/main/java/seedu/address/storage/event/JsonAdaptedEvent.java
@@ -19,6 +19,7 @@ import seedu.address.model.event.Event;
 import seedu.address.model.event.EventName;
 import seedu.address.model.event.Location;
 import seedu.address.model.event.Material;
+import seedu.address.model.event.MaxVolunteerSize;
 import seedu.address.model.event.Role;
 import seedu.address.model.volunteer.Name;
 
@@ -36,6 +37,7 @@ public class JsonAdaptedEvent {
     private final List<JsonAdaptedMaterial> materials = new ArrayList<>();
     private final String budget;
     private final List<JsonAdaptedName> assignedVolunteers = new ArrayList<>();
+    private final String maxVolunteerSize;
 
     /**
      * Constructs a {@code JsonAdaptedEvent} with the given event details.
@@ -49,7 +51,8 @@ public class JsonAdaptedEvent {
                             @JsonProperty("description") String description,
                             @JsonProperty("materials") List<JsonAdaptedMaterial> materials,
                             @JsonProperty("budget") String budget,
-                            @JsonProperty("assignedVolunteers") List<JsonAdaptedName> assignedVolunteers) {
+                            @JsonProperty("assignedVolunteers") List<JsonAdaptedName> assignedVolunteers,
+                            @JsonProperty("maxVolunteerSize") String maxVolunteerSize) {
         this.eventName = eventName;
         if (roles != null) {
             this.roles.addAll(roles);
@@ -65,6 +68,7 @@ public class JsonAdaptedEvent {
         if (assignedVolunteers != null) {
             this.assignedVolunteers.addAll(assignedVolunteers);
         }
+        this.maxVolunteerSize = maxVolunteerSize;
     }
 
     /**
@@ -86,6 +90,7 @@ public class JsonAdaptedEvent {
         assignedVolunteers.addAll(source.getAssignedVolunteers().stream()
                 .map(JsonAdaptedName::new)
                 .collect(Collectors.toList()));
+        maxVolunteerSize = source.getMaxVolunteerSize().toString();
     }
 
     /**
@@ -161,8 +166,21 @@ public class JsonAdaptedEvent {
             modelBudget = new Budget("");
         } else if (!Budget.isValidBudget(budget)) {
             throw new IllegalValueException(Budget.MESSAGE_CONSTRAINTS);
+        } else {
+            modelBudget = new Budget(budget);
         }
-        modelBudget = new Budget(budget);
+
+        MaxVolunteerSize modelMaxVolunteerSize;
+        if (maxVolunteerSize == null) {
+            throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT,
+                    MaxVolunteerSize.class.getSimpleName()));
+        } else if (maxVolunteerSize.isEmpty()) {
+            modelMaxVolunteerSize = new MaxVolunteerSize();
+        } else if (!MaxVolunteerSize.isValidMaxVolunteerSize(maxVolunteerSize)) {
+            throw new IllegalValueException(MaxVolunteerSize.MESSAGE_CONSTRAINTS);
+        } else {
+            modelMaxVolunteerSize = new MaxVolunteerSize(maxVolunteerSize);
+        }
 
         final List<Name> eventVolunteers = new ArrayList<>();
         for (JsonAdaptedName name : assignedVolunteers) {
@@ -173,7 +191,7 @@ public class JsonAdaptedEvent {
         final Set<Material> modelMaterials = new HashSet<>(eventMaterials);
         final Set<Name> modelAssignedVolunteers = new HashSet<>(eventVolunteers);
         return new Event(modelName, modelRoles, modelStartDate, modelEndDate, modelLocation, modelDescription,
-                modelMaterials, modelBudget, modelAssignedVolunteers);
+                modelMaterials, modelBudget, modelAssignedVolunteers, modelMaxVolunteerSize);
     }
 
 }

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -9,6 +9,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_END_DATETIME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EVENT_ID;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_LOCATION;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_MATERIAL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_MAX_VOLUNTEER_SIZE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ROLE;
@@ -57,6 +58,8 @@ public class CommandTestUtil {
     public static final String VALID_MATERIAL_HANDS = "30 hands";
     public static final String VALID_BUDGET_CLEANUP = "80.00";
     public static final String VALID_BUDGET_HELPOUT = "100.00";
+    public static final String VALID_MVS_CLEANUP = "3";
+    public static final String VALID_MVS_HELPOUT = "4";
     public static final String EVENTNAME_DESC_CLEANUP = " " + PREFIX_NAME + VALID_EVENTNAME_CLEANUP;
     public static final String EVENTNAME_DESC_HELPOUT = " " + PREFIX_NAME + VALID_EVENTNAME_HELPOUT;
     public static final String ROLE_DESC_CLEANER = " " + PREFIX_ROLE + VALID_ROLE_CLEANER;
@@ -73,6 +76,8 @@ public class CommandTestUtil {
     public static final String MATERIAL_DESC_HANDS = " " + PREFIX_MATERIAL + VALID_MATERIAL_HANDS;
     public static final String BUDGET_DESC_CLEANUP = " " + PREFIX_BUDGET + VALID_BUDGET_CLEANUP;
     public static final String BUDGET_DESC_HELPOUT = " " + PREFIX_BUDGET + VALID_BUDGET_HELPOUT;
+    public static final String MVS_DESC_CLEANUP = " " + PREFIX_MAX_VOLUNTEER_SIZE + VALID_MVS_CLEANUP;
+    public static final String MVS_DESC_HELPOUT = " " + PREFIX_MAX_VOLUNTEER_SIZE + VALID_MVS_HELPOUT;
     public static final String END_DATETIME_DESC_CLEANUP_BEFORE_START =
             " " + PREFIX_END_DATETIME + VALID_END_DATETIME_CLEANUP_BEFORE_START;
     public static final String EVENTID_DESC = " " + PREFIX_EVENT_ID;
@@ -87,6 +92,7 @@ public class CommandTestUtil {
     public static final String INVALID_DESCRIPTION_DESC = " " + PREFIX_DESCRIPTION + "clean&";
     public static final String INVALID_MATERIAL_DESC = " " + PREFIX_MATERIAL + "20 trash bag&";
     public static final String INVALID_BUDGET_DESC = " " + PREFIX_BUDGET + "50.0";
+    public static final String INVALID_MVS_DESC = " " + PREFIX_MAX_VOLUNTEER_SIZE + "-4&";
 
     // Volunteer fields
     public static final String VALID_NAME_AMY = "Amy Bee";

--- a/src/test/java/seedu/address/logic/commands/EditEventDescriptorTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditEventDescriptorTest.java
@@ -85,7 +85,8 @@ public class EditEventDescriptorTest {
                 + editEventDescriptor.getLocation().orElse(null) + ", description="
                 + editEventDescriptor.getDescription().orElse(null) + ", materials="
                 + editEventDescriptor.getMaterials().orElse(null) + ", budget="
-                + editEventDescriptor.getBudget().orElse(null) + "}";
+                + editEventDescriptor.getBudget().orElse(null) + ", max volunteer size="
+                + editEventDescriptor.getMaxVolunteerSize().orElse(null) + "}";
         assertEquals(expected, editEventDescriptor.toString());
     }
 }

--- a/src/test/java/seedu/address/logic/parser/EventCreateCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/EventCreateCommandParserTest.java
@@ -13,11 +13,13 @@ import static seedu.address.logic.commands.CommandTestUtil.INVALID_END_DATETIME_
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_EVENTNAME_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_LOCATION_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_MATERIAL_DESC;
+import static seedu.address.logic.commands.CommandTestUtil.INVALID_MVS_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_ROLE_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_START_DATETIME_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.LOCATION_DESC_CLEANUP;
 import static seedu.address.logic.commands.CommandTestUtil.MATERIAL_DESC_HANDS;
 import static seedu.address.logic.commands.CommandTestUtil.MATERIAL_DESC_TRASHBAG;
+import static seedu.address.logic.commands.CommandTestUtil.MVS_DESC_CLEANUP;
 import static seedu.address.logic.commands.CommandTestUtil.PREAMBLE_NON_EMPTY;
 import static seedu.address.logic.commands.CommandTestUtil.PREAMBLE_WHITESPACE;
 import static seedu.address.logic.commands.CommandTestUtil.ROLE_DESC_BRAIN;
@@ -36,6 +38,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_BUDGET;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_DESCRIPTION;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_END_DATETIME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_LOCATION;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_MAX_VOLUNTEER_SIZE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_START_DATETIME;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
@@ -54,6 +57,7 @@ import seedu.address.model.event.Event;
 import seedu.address.model.event.EventName;
 import seedu.address.model.event.Location;
 import seedu.address.model.event.Material;
+import seedu.address.model.event.MaxVolunteerSize;
 import seedu.address.model.event.Role;
 import seedu.address.testutil.EventBuilder;
 
@@ -67,7 +71,7 @@ public class EventCreateCommandParserTest {
         // whitespace only preamble
         assertParseSuccess(parser, PREAMBLE_WHITESPACE + EVENTNAME_DESC_CLEANUP + ROLE_DESC_CLEANER
                 + START_DATETIME_DESC_CLEANUP + END_DATETIME_DESC_CLEANUP + LOCATION_DESC_CLEANUP
-                + DESCRIPTION_DESC_CLEANUP + MATERIAL_DESC_TRASHBAG + BUDGET_DESC_CLEANUP,
+                + DESCRIPTION_DESC_CLEANUP + MATERIAL_DESC_TRASHBAG + BUDGET_DESC_CLEANUP + MVS_DESC_CLEANUP,
                 new EventCreateCommand(expectedEvent));
 
         // multiple roles and materials - all accepted
@@ -76,7 +80,8 @@ public class EventCreateCommandParserTest {
                 .withMaterials(VALID_MATERIAL_TRASHBAG, VALID_MATERIAL_HANDS).build();
         assertParseSuccess(parser, EVENTNAME_DESC_CLEANUP + ROLE_DESC_CLEANER + ROLE_DESC_BRAIN
                 + START_DATETIME_DESC_CLEANUP + END_DATETIME_DESC_CLEANUP + LOCATION_DESC_CLEANUP
-                + DESCRIPTION_DESC_CLEANUP + MATERIAL_DESC_TRASHBAG + MATERIAL_DESC_HANDS + BUDGET_DESC_CLEANUP,
+                + DESCRIPTION_DESC_CLEANUP + MATERIAL_DESC_TRASHBAG + MATERIAL_DESC_HANDS + BUDGET_DESC_CLEANUP
+                + MVS_DESC_CLEANUP,
                 new EventCreateCommand(expectedEventMultipleRolesAndMaterials));
     }
 
@@ -84,7 +89,7 @@ public class EventCreateCommandParserTest {
     public void parse_repeatedNonRoleOrMaterialValue_failure() {
         String validExpectedEventString = EVENTNAME_DESC_CLEANUP + ROLE_DESC_CLEANER
                 + START_DATETIME_DESC_CLEANUP + END_DATETIME_DESC_CLEANUP + LOCATION_DESC_CLEANUP
-                + DESCRIPTION_DESC_CLEANUP + MATERIAL_DESC_TRASHBAG + BUDGET_DESC_CLEANUP;
+                + DESCRIPTION_DESC_CLEANUP + MATERIAL_DESC_TRASHBAG + BUDGET_DESC_CLEANUP + MVS_DESC_CLEANUP;
 
         // multiple event names
         assertParseFailure(parser, EVENTNAME_DESC_CLEANUP + validExpectedEventString,
@@ -110,13 +115,17 @@ public class EventCreateCommandParserTest {
         assertParseFailure(parser, BUDGET_DESC_CLEANUP + validExpectedEventString,
                 Messages.getErrorMessageForDuplicatePrefixes(PREFIX_BUDGET));
 
+        // multiple max volunteer size params
+        assertParseFailure(parser, MVS_DESC_CLEANUP + validExpectedEventString,
+                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_MAX_VOLUNTEER_SIZE));
+
         // multiple fields repeated
         assertParseFailure(parser,
                 validExpectedEventString + EVENTNAME_DESC_CLEANUP + START_DATETIME_DESC_CLEANUP
                         + END_DATETIME_DESC_CLEANUP + LOCATION_DESC_CLEANUP + DESCRIPTION_DESC_CLEANUP
-                        + BUDGET_DESC_CLEANUP + validExpectedEventString,
+                        + BUDGET_DESC_CLEANUP + MVS_DESC_CLEANUP + validExpectedEventString,
                 Messages.getErrorMessageForDuplicatePrefixes(PREFIX_NAME, PREFIX_START_DATETIME, PREFIX_END_DATETIME,
-                        PREFIX_LOCATION, PREFIX_DESCRIPTION, PREFIX_BUDGET));
+                        PREFIX_LOCATION, PREFIX_DESCRIPTION, PREFIX_BUDGET, PREFIX_MAX_VOLUNTEER_SIZE));
 
         // invalid value followed by valid value
 
@@ -144,6 +153,10 @@ public class EventCreateCommandParserTest {
         assertParseFailure(parser, INVALID_BUDGET_DESC + validExpectedEventString,
                 Messages.getErrorMessageForDuplicatePrefixes(PREFIX_BUDGET));
 
+        // invalid max volunteer size
+        assertParseFailure(parser, INVALID_MVS_DESC + validExpectedEventString,
+                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_MAX_VOLUNTEER_SIZE));
+
         // valid value followed by invalid value
 
         // invalid event name
@@ -169,6 +182,10 @@ public class EventCreateCommandParserTest {
         // invalid budget
         assertParseFailure(parser, validExpectedEventString + INVALID_BUDGET_DESC,
                 Messages.getErrorMessageForDuplicatePrefixes(PREFIX_BUDGET));
+
+        // invalid max volunteer size
+        assertParseFailure(parser, validExpectedEventString + INVALID_MVS_DESC,
+                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_MAX_VOLUNTEER_SIZE));
     }
 
     @Test
@@ -177,23 +194,30 @@ public class EventCreateCommandParserTest {
         Event expectedEvent = new EventBuilder(CLEANUP).withMaterials().build();
         assertParseSuccess(parser, EVENTNAME_DESC_CLEANUP + ROLE_DESC_CLEANER + START_DATETIME_DESC_CLEANUP
                         + END_DATETIME_DESC_CLEANUP + LOCATION_DESC_CLEANUP + DESCRIPTION_DESC_CLEANUP
-                        + BUDGET_DESC_CLEANUP,
+                        + BUDGET_DESC_CLEANUP + MVS_DESC_CLEANUP,
                 new EventCreateCommand(expectedEvent));
 
         // zero budget
         expectedEvent = new EventBuilder(CLEANUP).withBudget("").build();
         assertParseSuccess(parser, EVENTNAME_DESC_CLEANUP + ROLE_DESC_CLEANER + START_DATETIME_DESC_CLEANUP
                         + END_DATETIME_DESC_CLEANUP + LOCATION_DESC_CLEANUP + DESCRIPTION_DESC_CLEANUP
-                        + MATERIAL_DESC_TRASHBAG,
+                        + MATERIAL_DESC_TRASHBAG + MVS_DESC_CLEANUP,
                 new EventCreateCommand(expectedEvent));
 
         // end date time not specified, defaults to 3 hours after start date time
         expectedEvent = new EventBuilder(CLEANUP).withEndDate(VALID_END_DATETIME_CLEANUP).build();
         assertParseSuccess(parser, EVENTNAME_DESC_CLEANUP + ROLE_DESC_CLEANER + START_DATETIME_DESC_CLEANUP
                         + LOCATION_DESC_CLEANUP + DESCRIPTION_DESC_CLEANUP + MATERIAL_DESC_TRASHBAG
-                        + BUDGET_DESC_CLEANUP,
+                        + BUDGET_DESC_CLEANUP + MVS_DESC_CLEANUP,
                 new EventCreateCommand(expectedEvent));
 
+        // maximum volunteer size not specified
+        String maxLongAsString = String.valueOf(Long.MAX_VALUE);
+        expectedEvent = new EventBuilder(CLEANUP).withMaxVolunteerSize(maxLongAsString).build();
+        assertParseSuccess(parser, EVENTNAME_DESC_CLEANUP + ROLE_DESC_CLEANER + START_DATETIME_DESC_CLEANUP
+                        + END_DATETIME_DESC_CLEANUP + LOCATION_DESC_CLEANUP + DESCRIPTION_DESC_CLEANUP
+                        + MATERIAL_DESC_TRASHBAG + BUDGET_DESC_CLEANUP,
+                new EventCreateCommand(expectedEvent));
     }
 
     @Test
@@ -204,37 +228,42 @@ public class EventCreateCommandParserTest {
         // missing event name prefix
         assertParseFailure(parser, VALID_EVENTNAME_CLEANUP + ROLE_DESC_CLEANER
                         + START_DATETIME_DESC_CLEANUP + END_DATETIME_DESC_CLEANUP + LOCATION_DESC_CLEANUP
-                        + DESCRIPTION_DESC_CLEANUP + MATERIAL_DESC_TRASHBAG + BUDGET_DESC_CLEANUP,
+                        + DESCRIPTION_DESC_CLEANUP + MATERIAL_DESC_TRASHBAG + BUDGET_DESC_CLEANUP
+                        + MVS_DESC_CLEANUP,
                 expectedMessage);
 
         // missing role prefix
         assertParseFailure(parser, EVENTNAME_DESC_CLEANUP + VALID_ROLE_CLEANER + START_DATETIME_DESC_CLEANUP
                         + END_DATETIME_DESC_CLEANUP + LOCATION_DESC_CLEANUP + DESCRIPTION_DESC_CLEANUP
-                        + MATERIAL_DESC_TRASHBAG + BUDGET_DESC_CLEANUP,
+                        + MATERIAL_DESC_TRASHBAG + BUDGET_DESC_CLEANUP + MVS_DESC_CLEANUP,
                 expectedMessage);
 
         // missing start date and time prefix
         assertParseFailure(parser, EVENTNAME_DESC_CLEANUP + ROLE_DESC_CLEANER
                         + VALID_START_DATETIME_CLEANUP + END_DATETIME_DESC_CLEANUP + LOCATION_DESC_CLEANUP
-                        + DESCRIPTION_DESC_CLEANUP + MATERIAL_DESC_TRASHBAG + BUDGET_DESC_CLEANUP,
+                        + DESCRIPTION_DESC_CLEANUP + MATERIAL_DESC_TRASHBAG + BUDGET_DESC_CLEANUP
+                        + MVS_DESC_CLEANUP,
                 expectedMessage);
 
         // missing location prefix
         assertParseFailure(parser, EVENTNAME_DESC_CLEANUP + ROLE_DESC_CLEANER
                         + START_DATETIME_DESC_CLEANUP + END_DATETIME_DESC_CLEANUP + VALID_LOCATION_CLEANUP
-                        + DESCRIPTION_DESC_CLEANUP + MATERIAL_DESC_TRASHBAG + BUDGET_DESC_CLEANUP,
+                        + DESCRIPTION_DESC_CLEANUP + MATERIAL_DESC_TRASHBAG + BUDGET_DESC_CLEANUP
+                        + MVS_DESC_CLEANUP,
                 expectedMessage);
 
         // missing description prefix
         assertParseFailure(parser, EVENTNAME_DESC_CLEANUP + ROLE_DESC_CLEANER
                         + START_DATETIME_DESC_CLEANUP + END_DATETIME_DESC_CLEANUP + LOCATION_DESC_CLEANUP
-                        + VALID_DESCRIPTION_CLEANUP + MATERIAL_DESC_TRASHBAG + BUDGET_DESC_CLEANUP,
+                        + VALID_DESCRIPTION_CLEANUP + MATERIAL_DESC_TRASHBAG + BUDGET_DESC_CLEANUP
+                        + MVS_DESC_CLEANUP,
                 expectedMessage);
 
         // all prefixes missing
         assertParseFailure(parser, VALID_EVENTNAME_CLEANUP + VALID_ROLE_CLEANER
                         + VALID_START_DATETIME_CLEANUP + END_DATETIME_DESC_CLEANUP + VALID_LOCATION_CLEANUP
-                        + VALID_DESCRIPTION_CLEANUP + MATERIAL_DESC_TRASHBAG + BUDGET_DESC_CLEANUP,
+                        + VALID_DESCRIPTION_CLEANUP + MATERIAL_DESC_TRASHBAG + BUDGET_DESC_CLEANUP
+                        + MVS_DESC_CLEANUP,
                 expectedMessage);
     }
 
@@ -243,61 +272,67 @@ public class EventCreateCommandParserTest {
         // invalid event name
         assertParseFailure(parser, INVALID_EVENTNAME_DESC + ROLE_DESC_CLEANER + START_DATETIME_DESC_CLEANUP
                 + END_DATETIME_DESC_CLEANUP + LOCATION_DESC_CLEANUP + DESCRIPTION_DESC_CLEANUP + MATERIAL_DESC_TRASHBAG
-                + BUDGET_DESC_CLEANUP,
+                + BUDGET_DESC_CLEANUP + MVS_DESC_CLEANUP,
                 EventName.MESSAGE_CONSTRAINTS);
 
         // invalid role
         assertParseFailure(parser, EVENTNAME_DESC_CLEANUP + INVALID_ROLE_DESC + START_DATETIME_DESC_CLEANUP
                 + END_DATETIME_DESC_CLEANUP + LOCATION_DESC_CLEANUP + DESCRIPTION_DESC_CLEANUP + MATERIAL_DESC_TRASHBAG
-                + BUDGET_DESC_CLEANUP,
+                + BUDGET_DESC_CLEANUP + MVS_DESC_CLEANUP,
                 Role.MESSAGE_CONSTRAINTS);
 
         // invalid start date and time
         assertParseFailure(parser, EVENTNAME_DESC_CLEANUP + ROLE_DESC_CLEANER + INVALID_START_DATETIME_DESC
                 + END_DATETIME_DESC_CLEANUP + LOCATION_DESC_CLEANUP + DESCRIPTION_DESC_CLEANUP + MATERIAL_DESC_TRASHBAG
-                + BUDGET_DESC_CLEANUP,
+                + BUDGET_DESC_CLEANUP + MVS_DESC_CLEANUP,
                 DateTime.MESSAGE_CONSTRAINTS);
 
         // invalid end date and time
         assertParseFailure(parser, EVENTNAME_DESC_CLEANUP + ROLE_DESC_CLEANER + START_DATETIME_DESC_CLEANUP
                         + INVALID_END_DATETIME_DESC + LOCATION_DESC_CLEANUP + DESCRIPTION_DESC_CLEANUP
-                        + MATERIAL_DESC_TRASHBAG + BUDGET_DESC_CLEANUP,
+                        + MATERIAL_DESC_TRASHBAG + BUDGET_DESC_CLEANUP + MVS_DESC_CLEANUP,
                 DateTime.MESSAGE_CONSTRAINTS);
 
         // invalid location
         assertParseFailure(parser, EVENTNAME_DESC_CLEANUP + ROLE_DESC_CLEANER + START_DATETIME_DESC_CLEANUP
                 + END_DATETIME_DESC_CLEANUP + INVALID_LOCATION_DESC + DESCRIPTION_DESC_CLEANUP + MATERIAL_DESC_TRASHBAG
-                + BUDGET_DESC_CLEANUP,
+                + BUDGET_DESC_CLEANUP + MVS_DESC_CLEANUP,
                 Location.MESSAGE_CONSTRAINTS);
 
         // invalid description
         assertParseFailure(parser, EVENTNAME_DESC_CLEANUP + ROLE_DESC_CLEANER + START_DATETIME_DESC_CLEANUP
                 + END_DATETIME_DESC_CLEANUP + LOCATION_DESC_CLEANUP + INVALID_DESCRIPTION_DESC + MATERIAL_DESC_TRASHBAG
-                + BUDGET_DESC_CLEANUP,
+                + BUDGET_DESC_CLEANUP + MVS_DESC_CLEANUP,
                 Description.MESSAGE_CONSTRAINTS);
 
         // invalid materials
         assertParseFailure(parser, EVENTNAME_DESC_CLEANUP + ROLE_DESC_CLEANER + START_DATETIME_DESC_CLEANUP
                 + END_DATETIME_DESC_CLEANUP + LOCATION_DESC_CLEANUP + DESCRIPTION_DESC_CLEANUP + INVALID_MATERIAL_DESC
-                + BUDGET_DESC_CLEANUP,
+                + BUDGET_DESC_CLEANUP + MVS_DESC_CLEANUP,
                 Material.MESSAGE_CONSTRAINTS);
 
         // invalid budget
         assertParseFailure(parser, EVENTNAME_DESC_CLEANUP + ROLE_DESC_CLEANER + START_DATETIME_DESC_CLEANUP
                 + END_DATETIME_DESC_CLEANUP + LOCATION_DESC_CLEANUP + DESCRIPTION_DESC_CLEANUP + MATERIAL_DESC_TRASHBAG
-                + INVALID_BUDGET_DESC,
+                + INVALID_BUDGET_DESC + MVS_DESC_CLEANUP,
                 Budget.MESSAGE_CONSTRAINTS);
+
+        // invalid max volunteer size
+        assertParseFailure(parser, EVENTNAME_DESC_CLEANUP + ROLE_DESC_CLEANER + START_DATETIME_DESC_CLEANUP
+                        + END_DATETIME_DESC_CLEANUP + LOCATION_DESC_CLEANUP + DESCRIPTION_DESC_CLEANUP
+                        + MATERIAL_DESC_TRASHBAG + BUDGET_DESC_CLEANUP + INVALID_MVS_DESC,
+                MaxVolunteerSize.MESSAGE_CONSTRAINTS);
 
         // two invalid values, only first invalid value reported
         assertParseFailure(parser, INVALID_EVENTNAME_DESC + INVALID_ROLE_DESC + START_DATETIME_DESC_CLEANUP
                 + END_DATETIME_DESC_CLEANUP + LOCATION_DESC_CLEANUP + DESCRIPTION_DESC_CLEANUP + MATERIAL_DESC_TRASHBAG
-                + BUDGET_DESC_CLEANUP,
+                + BUDGET_DESC_CLEANUP + MVS_DESC_CLEANUP,
                 EventName.MESSAGE_CONSTRAINTS);
 
         // non-empty preamble
         assertParseFailure(parser, PREAMBLE_NON_EMPTY + EVENTNAME_DESC_CLEANUP + ROLE_DESC_CLEANER
                         + START_DATETIME_DESC_CLEANUP + END_DATETIME_DESC_CLEANUP + LOCATION_DESC_CLEANUP
-                        + DESCRIPTION_DESC_CLEANUP + MATERIAL_DESC_TRASHBAG + BUDGET_DESC_CLEANUP,
+                        + DESCRIPTION_DESC_CLEANUP + MATERIAL_DESC_TRASHBAG + BUDGET_DESC_CLEANUP + MVS_DESC_CLEANUP,
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, EventCreateCommand.MESSAGE_USAGE));
     }
 
@@ -306,7 +341,7 @@ public class EventCreateCommandParserTest {
         // end datetime is before start datetime
         assertParseFailure(parser, EVENTNAME_DESC_CLEANUP + ROLE_DESC_CLEANER + START_DATETIME_DESC_CLEANUP
                         + END_DATETIME_DESC_CLEANUP_BEFORE_START + LOCATION_DESC_CLEANUP + DESCRIPTION_DESC_CLEANUP
-                        + MATERIAL_DESC_TRASHBAG + BUDGET_DESC_CLEANUP,
+                        + MATERIAL_DESC_TRASHBAG + BUDGET_DESC_CLEANUP + MVS_DESC_CLEANUP,
                 MESSAGE_INVALID_DATE_PARAMS);
     }
 
@@ -322,7 +357,7 @@ public class EventCreateCommandParserTest {
         // single test for equal start and end datetimes
         assertParseSuccess(parser, EVENTNAME_DESC_CLEANUP + ROLE_DESC_CLEANER + START_DATETIME_DESC_CLEANUP
                         + equalEndDatetime + LOCATION_DESC_CLEANUP + DESCRIPTION_DESC_CLEANUP
-                        + MATERIAL_DESC_TRASHBAG + BUDGET_DESC_CLEANUP,
+                        + MATERIAL_DESC_TRASHBAG + BUDGET_DESC_CLEANUP + MVS_DESC_CLEANUP,
                 new EventCreateCommand(expectedEvent));
     }
 }

--- a/src/test/java/seedu/address/model/event/EventTest.java
+++ b/src/test/java/seedu/address/model/event/EventTest.java
@@ -43,7 +43,8 @@ public class EventTest {
                 new Description("No description."),
                 firstMaterials,
                 firstBudget,
-                firstVList);
+                firstVList,
+                new MaxVolunteerSize("3"));
 
         // Creation of event that comes after default event from event builder
         EventName secondName = new EventName("Paint home");
@@ -69,7 +70,8 @@ public class EventTest {
                 new Description("No description."),
                 secondMaterials,
                 secondBudget,
-                secondVList);
+                secondVList,
+                new MaxVolunteerSize("3"));
 
         assertTrue(beforeCurrentEvent.getEventName().equals(new EventName("Clean home")));
         assertTrue(beforeCurrentEvent.getRoles().contains(clean));

--- a/src/test/java/seedu/address/storage/event/JsonAdaptedEventTest.java
+++ b/src/test/java/seedu/address/storage/event/JsonAdaptedEventTest.java
@@ -34,6 +34,7 @@ public class JsonAdaptedEventTest {
     private static final String VALID_LOCATION = FIRST.getLocation().toString();
     private static final String VALID_DESCRIPTION = FIRST.getDescription().toString();
     private static final String VALID_BUDGET = FIRST.getBudget().toString();
+    private static final String VALID_MAX_VOLUNTEER_SIZE = FIRST.getMaxVolunteerSize().toString();
     private static final List<JsonAdaptedName> VALID_ASSIGNED_VOLUNTEERS = FIRST.getAssignedVolunteers().stream()
             .map(JsonAdaptedName::new)
             .collect(Collectors.toList());
@@ -54,7 +55,8 @@ public class JsonAdaptedEventTest {
     public void toModelType_invalidEventName_throwsIllegalValueException() {
         JsonAdaptedEvent event =
                 new JsonAdaptedEvent(INVALID_EVENT_NAME, VALID_ROLES, VALID_START_DATE, VALID_END_DATE,
-                        VALID_LOCATION, VALID_DESCRIPTION, VALID_MATERIALS, VALID_BUDGET, VALID_ASSIGNED_VOLUNTEERS);
+                        VALID_LOCATION, VALID_DESCRIPTION, VALID_MATERIALS, VALID_BUDGET, VALID_ASSIGNED_VOLUNTEERS,
+                        VALID_MAX_VOLUNTEER_SIZE);
         String expectedMessage = EventName.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, event::toModelType);
     }
@@ -63,7 +65,8 @@ public class JsonAdaptedEventTest {
     public void toModelType_nullEventName_throwsIllegalValueException() {
         JsonAdaptedEvent event =
                 new JsonAdaptedEvent(null, VALID_ROLES, VALID_START_DATE, VALID_END_DATE,
-                        VALID_LOCATION, VALID_DESCRIPTION, VALID_MATERIALS, VALID_BUDGET, VALID_ASSIGNED_VOLUNTEERS);
+                        VALID_LOCATION, VALID_DESCRIPTION, VALID_MATERIALS, VALID_BUDGET, VALID_ASSIGNED_VOLUNTEERS,
+                        VALID_MAX_VOLUNTEER_SIZE);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, EventName.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, event::toModelType);
     }
@@ -72,7 +75,8 @@ public class JsonAdaptedEventTest {
     public void toModelType_invalidStartDate_throwsIllegalValueException() {
         JsonAdaptedEvent event =
                 new JsonAdaptedEvent(VALID_EVENT_NAME, VALID_ROLES, INVALID_START_DATE, VALID_END_DATE,
-                        VALID_LOCATION, VALID_DESCRIPTION, VALID_MATERIALS, VALID_BUDGET, VALID_ASSIGNED_VOLUNTEERS);
+                        VALID_LOCATION, VALID_DESCRIPTION, VALID_MATERIALS, VALID_BUDGET, VALID_ASSIGNED_VOLUNTEERS,
+                        VALID_MAX_VOLUNTEER_SIZE);
         String expectedMessage = DateTime.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, event::toModelType);
     }
@@ -81,7 +85,8 @@ public class JsonAdaptedEventTest {
     public void toModelType_nullStartDate_throwsIllegalValueException() {
         JsonAdaptedEvent event =
                 new JsonAdaptedEvent(VALID_EVENT_NAME, VALID_ROLES, null, VALID_END_DATE,
-                        VALID_LOCATION, VALID_DESCRIPTION, VALID_MATERIALS, VALID_BUDGET, VALID_ASSIGNED_VOLUNTEERS);
+                        VALID_LOCATION, VALID_DESCRIPTION, VALID_MATERIALS, VALID_BUDGET, VALID_ASSIGNED_VOLUNTEERS,
+                        VALID_MAX_VOLUNTEER_SIZE);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, DateTime.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, event::toModelType);
     }
@@ -90,7 +95,8 @@ public class JsonAdaptedEventTest {
     public void toModelType_invalidEndDate_throwsIllegalValueException() {
         JsonAdaptedEvent event =
                 new JsonAdaptedEvent(VALID_EVENT_NAME, VALID_ROLES, VALID_START_DATE, INVALID_END_DATE,
-                        VALID_LOCATION, VALID_DESCRIPTION, VALID_MATERIALS, VALID_BUDGET, VALID_ASSIGNED_VOLUNTEERS);
+                        VALID_LOCATION, VALID_DESCRIPTION, VALID_MATERIALS, VALID_BUDGET, VALID_ASSIGNED_VOLUNTEERS,
+                        VALID_MAX_VOLUNTEER_SIZE);
         String expectedMessage = DateTime.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, event::toModelType);
     }
@@ -99,7 +105,8 @@ public class JsonAdaptedEventTest {
     public void toModelType_nullEndDate_throwsIllegalValueException() {
         JsonAdaptedEvent event =
                 new JsonAdaptedEvent(VALID_EVENT_NAME, VALID_ROLES, VALID_START_DATE, null,
-                        VALID_LOCATION, VALID_DESCRIPTION, VALID_MATERIALS, VALID_BUDGET, VALID_ASSIGNED_VOLUNTEERS);
+                        VALID_LOCATION, VALID_DESCRIPTION, VALID_MATERIALS, VALID_BUDGET, VALID_ASSIGNED_VOLUNTEERS,
+                        VALID_MAX_VOLUNTEER_SIZE);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, DateTime.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, event::toModelType);
     }
@@ -108,7 +115,8 @@ public class JsonAdaptedEventTest {
     public void toModelType_invalidLocation_throwsIllegalValueException() {
         JsonAdaptedEvent event =
                 new JsonAdaptedEvent(VALID_EVENT_NAME, VALID_ROLES, VALID_START_DATE, VALID_END_DATE,
-                        INVALID_LOCATION, VALID_DESCRIPTION, VALID_MATERIALS, VALID_BUDGET, VALID_ASSIGNED_VOLUNTEERS);
+                        INVALID_LOCATION, VALID_DESCRIPTION, VALID_MATERIALS, VALID_BUDGET, VALID_ASSIGNED_VOLUNTEERS,
+                        VALID_MAX_VOLUNTEER_SIZE);
         String expectedMessage = Location.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, event::toModelType);
     }
@@ -117,7 +125,8 @@ public class JsonAdaptedEventTest {
     public void toModelType_nullLocation_throwsIllegalValueException() {
         JsonAdaptedEvent event =
                 new JsonAdaptedEvent(VALID_EVENT_NAME, VALID_ROLES, VALID_START_DATE, VALID_END_DATE,
-                        null, VALID_DESCRIPTION, VALID_MATERIALS, VALID_BUDGET, VALID_ASSIGNED_VOLUNTEERS);
+                        null, VALID_DESCRIPTION, VALID_MATERIALS, VALID_BUDGET, VALID_ASSIGNED_VOLUNTEERS,
+                        VALID_MAX_VOLUNTEER_SIZE);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Location.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, event::toModelType);
     }
@@ -126,7 +135,8 @@ public class JsonAdaptedEventTest {
     public void toModelType_invalidDescription_throwsIllegalValueException() {
         JsonAdaptedEvent event =
                 new JsonAdaptedEvent(VALID_EVENT_NAME, VALID_ROLES, VALID_START_DATE, VALID_END_DATE,
-                        VALID_LOCATION, INVALID_DESCRIPTION, VALID_MATERIALS, VALID_BUDGET, VALID_ASSIGNED_VOLUNTEERS);
+                        VALID_LOCATION, INVALID_DESCRIPTION, VALID_MATERIALS, VALID_BUDGET, VALID_ASSIGNED_VOLUNTEERS,
+                        VALID_MAX_VOLUNTEER_SIZE);
         String expectedMessage = Description.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, event::toModelType);
     }
@@ -135,7 +145,8 @@ public class JsonAdaptedEventTest {
     public void toModelType_nullDescription_throwsIllegalValueException() {
         JsonAdaptedEvent event =
                 new JsonAdaptedEvent(VALID_EVENT_NAME, VALID_ROLES, VALID_START_DATE, VALID_END_DATE,
-                        VALID_LOCATION, null, VALID_MATERIALS, VALID_BUDGET, VALID_ASSIGNED_VOLUNTEERS);
+                        VALID_LOCATION, null, VALID_MATERIALS, VALID_BUDGET, VALID_ASSIGNED_VOLUNTEERS,
+                        VALID_MAX_VOLUNTEER_SIZE);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Description.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, event::toModelType);
     }
@@ -144,7 +155,8 @@ public class JsonAdaptedEventTest {
     public void toModelType_invalidBudget_throwsIllegalValueException() {
         JsonAdaptedEvent event =
                 new JsonAdaptedEvent(VALID_EVENT_NAME, VALID_ROLES, VALID_START_DATE, VALID_END_DATE,
-                        VALID_LOCATION, VALID_DESCRIPTION, VALID_MATERIALS, INVALID_BUDGET, VALID_ASSIGNED_VOLUNTEERS);
+                        VALID_LOCATION, VALID_DESCRIPTION, VALID_MATERIALS, INVALID_BUDGET, VALID_ASSIGNED_VOLUNTEERS,
+                        VALID_MAX_VOLUNTEER_SIZE);
         String expectedMessage = Budget.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, event::toModelType);
     }
@@ -153,7 +165,8 @@ public class JsonAdaptedEventTest {
     public void toModelType_nullBudget_throwsIllegalValueException() {
         JsonAdaptedEvent event =
                 new JsonAdaptedEvent(VALID_EVENT_NAME, VALID_ROLES, VALID_START_DATE, VALID_END_DATE,
-                        VALID_LOCATION, VALID_DESCRIPTION, VALID_MATERIALS, null, VALID_ASSIGNED_VOLUNTEERS);
+                        VALID_LOCATION, VALID_DESCRIPTION, VALID_MATERIALS, null, VALID_ASSIGNED_VOLUNTEERS,
+                        VALID_MAX_VOLUNTEER_SIZE);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Budget.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, event::toModelType);
     }
@@ -165,7 +178,8 @@ public class JsonAdaptedEventTest {
         invalidRoles1.add(new JsonAdaptedRole(INVALID_ROLE));
         JsonAdaptedEvent event =
                 new JsonAdaptedEvent(VALID_EVENT_NAME, invalidRoles1, VALID_START_DATE, VALID_END_DATE,
-                        VALID_LOCATION, VALID_DESCRIPTION, VALID_MATERIALS, VALID_BUDGET, VALID_ASSIGNED_VOLUNTEERS);
+                        VALID_LOCATION, VALID_DESCRIPTION, VALID_MATERIALS, VALID_BUDGET, VALID_ASSIGNED_VOLUNTEERS,
+                        VALID_MAX_VOLUNTEER_SIZE);
         assertThrows(IllegalValueException.class, event::toModelType);
 
         // test 2: invalid current quantity
@@ -173,7 +187,8 @@ public class JsonAdaptedEventTest {
         invalidRoles2.add(new JsonAdaptedRole("chefs", "-2", "30"));
         JsonAdaptedEvent event2 =
                 new JsonAdaptedEvent(VALID_EVENT_NAME, invalidRoles2, VALID_START_DATE, VALID_END_DATE,
-                        VALID_LOCATION, VALID_DESCRIPTION, VALID_MATERIALS, VALID_BUDGET, VALID_ASSIGNED_VOLUNTEERS);
+                        VALID_LOCATION, VALID_DESCRIPTION, VALID_MATERIALS, VALID_BUDGET, VALID_ASSIGNED_VOLUNTEERS,
+                        VALID_MAX_VOLUNTEER_SIZE);
         assertThrows(IllegalValueException.class, event2::toModelType);
 
         // test 3: invalid required quantity
@@ -181,7 +196,8 @@ public class JsonAdaptedEventTest {
         invalidRoles3.add(new JsonAdaptedRole("cleaners", "30", "-2"));
         JsonAdaptedEvent event3 =
                 new JsonAdaptedEvent(VALID_EVENT_NAME, invalidRoles3, VALID_START_DATE, VALID_END_DATE,
-                        VALID_LOCATION, VALID_DESCRIPTION, VALID_MATERIALS, VALID_BUDGET, VALID_ASSIGNED_VOLUNTEERS);
+                        VALID_LOCATION, VALID_DESCRIPTION, VALID_MATERIALS, VALID_BUDGET, VALID_ASSIGNED_VOLUNTEERS,
+                        VALID_MAX_VOLUNTEER_SIZE);
         assertThrows(IllegalValueException.class, event3::toModelType);
     }
 
@@ -192,7 +208,8 @@ public class JsonAdaptedEventTest {
         invalidMaterials1.add(new JsonAdaptedMaterial(INVALID_MATERIAL));
         JsonAdaptedEvent event1 =
                 new JsonAdaptedEvent(VALID_EVENT_NAME, VALID_ROLES, VALID_START_DATE, VALID_END_DATE,
-                        VALID_LOCATION, VALID_DESCRIPTION, invalidMaterials1, VALID_BUDGET, VALID_ASSIGNED_VOLUNTEERS);
+                        VALID_LOCATION, VALID_DESCRIPTION, invalidMaterials1, VALID_BUDGET, VALID_ASSIGNED_VOLUNTEERS,
+                        VALID_MAX_VOLUNTEER_SIZE);
         assertThrows(IllegalValueException.class, event1::toModelType);
 
         // test 2: invalid current quantity
@@ -200,7 +217,8 @@ public class JsonAdaptedEventTest {
         invalidMaterials2.add(new JsonAdaptedMaterial("trash bags", "-2", "30"));
         JsonAdaptedEvent event2 =
                 new JsonAdaptedEvent(VALID_EVENT_NAME, VALID_ROLES, VALID_START_DATE, VALID_END_DATE,
-                        VALID_LOCATION, VALID_DESCRIPTION, invalidMaterials2, VALID_BUDGET, VALID_ASSIGNED_VOLUNTEERS);
+                        VALID_LOCATION, VALID_DESCRIPTION, invalidMaterials2, VALID_BUDGET, VALID_ASSIGNED_VOLUNTEERS,
+                        VALID_MAX_VOLUNTEER_SIZE);
         assertThrows(IllegalValueException.class, event2::toModelType);
 
         // test 3: invalid required quantity
@@ -208,7 +226,8 @@ public class JsonAdaptedEventTest {
         invalidMaterials3.add(new JsonAdaptedMaterial("trash bags", "30", "-2"));
         JsonAdaptedEvent event3 =
                 new JsonAdaptedEvent(VALID_EVENT_NAME, VALID_ROLES, VALID_START_DATE, VALID_END_DATE,
-                        VALID_LOCATION, VALID_DESCRIPTION, invalidMaterials3, VALID_BUDGET, VALID_ASSIGNED_VOLUNTEERS);
+                        VALID_LOCATION, VALID_DESCRIPTION, invalidMaterials3, VALID_BUDGET, VALID_ASSIGNED_VOLUNTEERS,
+                        VALID_MAX_VOLUNTEER_SIZE);
         assertThrows(IllegalValueException.class, event3::toModelType);
     }
 }

--- a/src/test/java/seedu/address/testutil/EventBuilder.java
+++ b/src/test/java/seedu/address/testutil/EventBuilder.java
@@ -10,6 +10,7 @@ import seedu.address.model.event.Event;
 import seedu.address.model.event.EventName;
 import seedu.address.model.event.Location;
 import seedu.address.model.event.Material;
+import seedu.address.model.event.MaxVolunteerSize;
 import seedu.address.model.event.Role;
 import seedu.address.model.util.SampleDataUtil;
 import seedu.address.model.volunteer.Name;
@@ -24,6 +25,7 @@ public class EventBuilder {
     public static final String DEFAULT_LOCATION = "Hougang";
     public static final String DEFAULT_DESCRIPTION = "Clean very clean";
     public static final String DEFAULT_BUDGET = "50.00";
+    public static final String DEFAULT_MAX_VOLUNTEER_SIZE = "3";
 
     private EventName eventName;
     private Set<Role> roles;
@@ -34,6 +36,7 @@ public class EventBuilder {
     private Set<Material> materials;
     private Budget budget;
     private Set<Name> assignedVolunteers = new HashSet<>();
+    private MaxVolunteerSize maxVolunteerSize;
 
     /**
      * Creates a {@code EventBuilder} with the default details.
@@ -47,6 +50,7 @@ public class EventBuilder {
         description = new Description(DEFAULT_DESCRIPTION);
         materials = new HashSet<>();
         budget = new Budget(DEFAULT_BUDGET);
+        maxVolunteerSize = new MaxVolunteerSize(DEFAULT_MAX_VOLUNTEER_SIZE);
     }
 
     /**
@@ -61,6 +65,7 @@ public class EventBuilder {
         description = eventToCopy.getDescription();
         materials = new HashSet<>(eventToCopy.getMaterials());
         budget = eventToCopy.getBudget();
+        maxVolunteerSize = eventToCopy.getMaxVolunteerSize();
     }
 
     /**
@@ -128,12 +133,20 @@ public class EventBuilder {
     }
 
     /**
+     * Sets the {@code MaxVolunteerSize} of the {@code Event} that we are building.
+     */
+    public EventBuilder withMaxVolunteerSize(String maxVolunteerSize) {
+        this.maxVolunteerSize = new MaxVolunteerSize(maxVolunteerSize);
+        return this;
+    }
+
+    /**
      * Creates an event object.
      * @return the {@code Event} object
      */
     public Event build() {
         return new Event(eventName, roles, startDate, endDate, location, description, materials, budget,
-                assignedVolunteers);
+                assignedVolunteers, maxVolunteerSize);
     }
 
 }


### PR DESCRIPTION
- Add functionality to add maximum volunteers to event using the `ecreate`'s optional `vs/` parameter. For example, `vs/2` causes the maximum to be 2 volunteers, while `vs/0` removes the limit of the number of volunteers.
- For `eedit`, the `vs/` parameter works as well, with an extra check to ensure the new maximum is not lower than the number of volunteers already in the event's volunteer list
- Functionality affects the `eaddv` command, and will be shown in eshow